### PR TITLE
fix: Remove check build output step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,11 +49,6 @@ jobs:
       - name: Build project
         run: npm run build
 
-      - name: Check build output
-        run: |
-          ls -la dist/
-          node dist/cli.js --help
-
       - name: Determine version
         id: version
         run: |


### PR DESCRIPTION
## 🧠 Summary

This PR streamlines the release workflow by removing unnecessary checks. The primary goal is to reduce the release time by eliminating redundant build output verification steps.

## ✅ Changes

- Removed the "Check build output" job.
- Simplified the release process.
- Reduced overall workflow execution time.