### PR TITLE
feat: Implement get default provider function in ai provider manager

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ on:
         description: 'Custom version (if version is set to custom)'
         required: false
         type: string
+      publish_to_npm:
+        description: 'Publish to NPM Package Registry'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   release:
@@ -110,3 +115,38 @@ jobs:
         run: |
           git checkout -b release/v${{ steps.version.outputs.VERSION }}
           git push origin release/v${{ steps.version.outputs.VERSION }}
+
+  publish-npm:
+    needs: release
+    if: ${{ github.event.inputs.publish_to_npm == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Update package.json version
+        run: |
+          if [ "${{ github.event.inputs.version }}" = "custom" ]; then
+            npm version ${{ github.event.inputs.custom_version }} --no-git-tag-version
+          else
+            npm version ${{ github.event.inputs.version }} --no-git-tag-version
+          fi
+
+      - name: Publish to NPM
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## 🧠 Summary
This PR introduces the ability to specify a default AI provider in the application configuration. It also updates the PR generator to utilize this default provider when generating content, falling back to the first available provider if no default is set.

## ✅ Changes
*   Added `getDefaultProvider` method to the `ProviderManager` to retrieve the configured default provider name.
*   Updated `getCurrentProvider` in `PRGenerator` to prioritize the default provider if it's configured.
*   Added unit tests for `getDefaultProvider` in `ProviderManager` to ensure correct behavior.
*   Added unit tests for `getCurrentProvider` in `PRGenerator` to test the default provider logic.